### PR TITLE
Fix CMake extension name to correctly place .pyd inside package directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
     description="LiteHtmlPy is a solution that helps python developers to create printouts and previews of html5/css3 pages without using a web browser.",
     long_description="",
     ext_modules=[
-        CMakeExtension("litehtmlpy")
+        CMakeExtension("litehtmlpy.litehtmlpy")
     ],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,


### PR DESCRIPTION
### Problem
The CMakeExtension in `setup.py` was previously defined as `"litehtmlpy"`. This caused the compiled `.pyd` file to be placed in the top-level installation directory (e.g., `site-packages/litehtmlpy.cp310-win_amd64.pyd`), rather than inside the `litehtmlpy/` package.

As a result, importing the package with `from . import litehtmlpy` failed.

### Solution
This PR changes the extension name to `litehtmlpy.litehtmlpy`, ensuring that the compiled binary is correctly installed as:
`site-packages/litehtmlpy/litehtmlpy.cp310-win_amd64.pyd`

### Result
After installing the package, `import litehtmlpy` works as expected. All dependent modules are now correctly importable.

### Additional Notes
No changes to the C++ or CMake source were needed—this is purely a packaging fix.
